### PR TITLE
Use staged dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 node_modules/
 .devcontainer/
 data/
-prisma/
 .env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,28 @@
-FROM oven/bun:slim
-
+FROM oven/bun:slim AS base
 WORKDIR /app
 
-COPY . .
+# separate install step into another image so that
+# Docker can cache it
+FROM base AS install
+RUN mkdir -p /temp/dev
+COPY package.json bun.lock /temp/dev/
+RUN cd /temp/dev && bun i --frozen-lockfile
 
-RUN bun i
+RUN mkdir -p /temp/prod
+COPY package.json bun.lock /temp/prod/
+RUN cd /temp/prod && bun i --frozen-lockfile --production
+
+# Generate the Prisma client
+FROM base AS prisma
+COPY prisma prisma
+COPY --from=install /temp/dev/node_modules node_modules
+RUN bunx prisma generate
+
+FROM base AS release
+COPY --from=install /temp/prod/node_modules node_modules
+COPY --from=prisma /app/node_modules/.prisma/client node_modules/.prisma/client
+COPY --from=prisma /app/prisma prisma
+COPY src src
+COPY entrypoint.sh package.json ./
 
 CMD [ "/bin/bash", "entrypoint.sh" ]


### PR DESCRIPTION
Speeds up docker build by caching package installs.

好的，这是将 pull request 总结翻译成中文的结果：

## Sourcery 总结

构建：
- 缓存 `bun install`，将其安装过程分离到一个专门的阶段。

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

构建：
- 缓存 `bun install`：通过将安装过程分离到一个专门的阶段来实现。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Cache `bun install` by separating the installation process into a dedicated stage.

</details>

</details>